### PR TITLE
Bugfix/fix nesting issue with slots

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -54,7 +54,7 @@
 
 <br />
 
-<h2>Slotted Component with Nesting</h2>
+<h2>Slotted Component with Additional Slot Nesting</h2>
 
 <card-sample>
     <slot name="cardHeader">
@@ -77,6 +77,17 @@
 </card-sample>
 
 <br />
+
+<h2>Slotted Component non-slot Component Nesting</h2>
+<card-sample>
+    <slot name="cardHeader">
+        <h4>This is your first slot.</h4>
+    </slot>
+    <hello-world />
+    <slot name="cardFooter">
+        <h2>This is your second slot.</h2>
+    </slot>
+</card-sample>
 
 <h2>Slotted Component with Fallback</h2>
 

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -54,7 +54,7 @@
 
 <br />
 
-<h2>Slotted Component with Additional Slot Nesting</h2>
+<h2>Slotted Component with nested component (which also has slots)</h2>
 
 <card-sample>
     <slot name="cardHeader">
@@ -78,7 +78,7 @@
 
 <br />
 
-<h2>Slotted Component non-slot Component Nesting</h2>
+<h2>Slotted Component with nested component (which doesn't have slots)</h2>
 <card-sample>
     <slot name="cardHeader">
         <h4>This is your first slot.</h4>

--- a/RazorComponentTagHelpers.Web.csproj
+++ b/RazorComponentTagHelpers.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>4f9f8f90-8d46-498a-bd9d-93f2b96f5fc6</UserSecretsId>

--- a/TagHelperComponents/RazorComponentSlotTagHelper.cs
+++ b/TagHelperComponents/RazorComponentSlotTagHelper.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.AspNetCore.Razor.TagHelpers;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace TechGems.RazorComponentTagHelpers;

--- a/TagHelperComponents/RazorComponentTagHelper.cs
+++ b/TagHelperComponents/RazorComponentTagHelper.cs
@@ -177,6 +177,15 @@ public abstract class RazorComponentTagHelper : TagHelper
         {
             await RenderPartialView(_razorViewRoute, output);
         }
+
+        if (this is not RazorComponentSlotTagHelper)
+        {
+            var stack = GetParentComponentStack(context);
+            if (stack.Count > 0 && stack.Peek() == this)
+            {
+                stack.Pop();
+            }
+        }
     }
 
     /// <summary>

--- a/TagHelperComponents/RazorComponentTagHelper.cs
+++ b/TagHelperComponents/RazorComponentTagHelper.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Mvc.Rendering;
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -58,16 +57,18 @@ public abstract class RazorComponentTagHelper : TagHelper
     /// Property used for determining if you need a fallback on your child content.
     /// </summary>
     [HtmlAttributeNotBound]
-    public bool IsChildContentNullOrEmpty { 
-        get { 
-            if(ChildContent is null)
+    public bool IsChildContentNullOrEmpty
+    {
+        get
+        {
+            if (ChildContent is null)
                 return true;
 
-            if(ChildContent.IsEmptyOrWhiteSpace)
+            if (ChildContent.IsEmptyOrWhiteSpace)
                 return true;
 
             return false;
-        } 
+        }
     }
 
     public bool IsSlotContentNullOrEmpty(string slotName)
@@ -147,7 +148,8 @@ public abstract class RazorComponentTagHelper : TagHelper
 
             ParentComponent = parentComponentStack.Peek();
 
-            if(this is not RazorComponentSlotTagHelper) { 
+            if (this is not RazorComponentSlotTagHelper)
+            {
                 parentComponentStack.Push(this);
             }
         }
@@ -169,8 +171,8 @@ public abstract class RazorComponentTagHelper : TagHelper
             throw new ArgumentNullException(nameof(ViewContext));
         }
 
-        if (_razorViewRoute is null) 
-        { 
+        if (_razorViewRoute is null)
+        {
             await RenderPartialView(output);
         }
         else
@@ -195,7 +197,7 @@ public abstract class RazorComponentTagHelper : TagHelper
     /// <param name="viewRoute"></param>
     /// <param name="output"></param>
     /// <returns></returns>
-    protected async Task RenderPartialView(string viewRoute, TagHelperOutput output) 
+    protected async Task RenderPartialView(string viewRoute, TagHelperOutput output)
     {
         var childContent = await output.GetChildContentAsync();
 

--- a/TagHelperComponents/TechGems.RazorComponentTagHelpers.csproj
+++ b/TagHelperComponents/TechGems.RazorComponentTagHelpers.csproj
@@ -1,24 +1,24 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net6</TargetFramework>
-		<Nullable>enable</Nullable>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>1.1.1</Version>
-		<Authors>Carlos Jimenez</Authors>
-		<Company>Tech Gems</Company>
-		<Product>Razor Component Tag Helpers</Product>
-		<Description>Razor Component Tag Helpers is a small, minimalistic library that lets you write tag helpers as Razor powered static components. Great to use when you want better UI composition but you just want to use MVC or Razor Pages.</Description>
-		<RepositoryUrl>https://github.com/techgems/razor-component-tag-helpers</RepositoryUrl>
-		<RepositoryType>Public</RepositoryType>
-		<PackageTags>components;mvc;razor-pages;tag-helpers</PackageTags>
-		<FileVersion>1.1.1</FileVersion>
-		<PackageId>TechGems.RazorComponentTagHelpers</PackageId>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>1.1.1</Version>
+    <Authors>Carlos Jimenez</Authors>
+    <Company>Tech Gems</Company>
+    <Product>Razor Component Tag Helpers</Product>
+    <Description>Razor Component Tag Helpers is a small, minimalistic library that lets you write tag helpers as Razor powered static components. Great to use when you want better UI composition but you just want to use MVC or Razor Pages.</Description>
+    <RepositoryUrl>https://github.com/techgems/razor-component-tag-helpers</RepositoryUrl>
+    <RepositoryType>Public</RepositoryType>
+    <PackageTags>components;mvc;razor-pages;tag-helpers</PackageTags>
+    <FileVersion>1.1.1</FileVersion>
+    <PackageId>TechGems.RazorComponentTagHelpers</PackageId>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-	</ItemGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
 </Project>

--- a/TagHelperComponents/TechGems.RazorComponentTagHelpers.csproj
+++ b/TagHelperComponents/TechGems.RazorComponentTagHelpers.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6</TargetFramework>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<Version>1.1.0</Version>
+		<Version>1.1.1</Version>
 		<Authors>Carlos Jimenez</Authors>
 		<Company>Tech Gems</Company>
 		<Product>Razor Component Tag Helpers</Product>
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/techgems/razor-component-tag-helpers</RepositoryUrl>
 		<RepositoryType>Public</RepositoryType>
 		<PackageTags>components;mvc;razor-pages;tag-helpers</PackageTags>
-		<FileVersion>1.1.0</FileVersion>
+		<FileVersion>1.1.1</FileVersion>
 		<PackageId>TechGems.RazorComponentTagHelpers</PackageId>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>


### PR DESCRIPTION
There is currently a bug with slots which can be seen when a non-slot component is rendered before the last slot. For example, using the card-sample:
```cshtml
<card-sample>
    <slot name="cardHeader">
        <h4>This is your first slot.</h4>
    </slot>
    <hello-world/>
    <slot name="cardFooter">
        <h4>This is your second slot.</h4>
    </slot>
</card-sample>
```

The expected output is:
![image](https://github.com/user-attachments/assets/3489af29-ef04-4654-8a85-e4e1f9a2d0e3)

The actual output is:
![image](https://github.com/user-attachments/assets/0cf4e0dd-acd7-405a-9b79-d3b5608badbf)

This is failing due to the hello-world component never being popped off the top of the stack, so when it gets to processing the next slot, it has an invalid reference to a hello-world component, which of course doesn't have a slot definition in its slot dictionary. In this case, it fails "gracefully" as there is a content fallback, but if you remove it, it completely exceptions out.
```cshtml
    <div class="cardFooter">
        @Model.RenderSlot("cardFooter")
    </div>
```
![image](https://github.com/user-attachments/assets/b29bebb3-8fd8-446d-ae8f-1f9de742a186)